### PR TITLE
Add Google Poly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Graphics
 * :money_with_wings: [CGTextures](http://www.textures.com) - A large collection of textures.
 * :money_with_wings: [GameDev Market](https://www.gamedevmarket.net/) - a community-driven marketplace that connects indie game developers with talented asset creators.
 * :free: [Games-Icons Set](http://game-icons.net/) - free icons for your games.
+* :free: [Google Poly](https://poly.google.com/) - Searchable database of 3D models with rotatable previews. (Only remixable models are downloadable.)
 * :free: [Iconmonstr](http://iconmonstr.com/) - Another free icons resource for your games.
 * :money_with_wings: [Kenney Assets](http://kenney.nl/assets) - Royalty free assets
 * :free: [Liberated Pixel Cup assets](http://lpc.opengameart.org) - Free graphic assets of the Liberated Pixel Cup (LPC) held by the OpenGameArt forums


### PR DESCRIPTION
Google Poly seems like a nice UI for searching for 3D models. It's a bit annoying because you have to change the search options to remixable to find ones you can download. Models seem to all be OBJ files.

Seems to compare favourably in user experience to other options (blender-models requires facebook likes to download, Yobi3D has several steps to find download links on other websites). But selection is probably worse (best content seems to be provided by Google).

Why do you think the link is worth adding on this list?
Please describe the answer here

Does this project has any License?
Please describe the answer here

