### PR TITLE
Added EnTT to the list of frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Code
 * :tada: [jMonkeyEngine 3](http://jmonkeyengine.org/) - a 3D open-source game engine for adventurous Java developers.
 * :tada: [p2.js](http://schteppe.github.io/p2.js/) - JavaScript 2D physics library
 * :tada: [voxel.js](http://voxeljs.com/) - voxel.js is a collection of projects that make it easier than ever to create 3D voxel games like Minecraft all in the browser.
+* :tada: [EnTT](https://github.com/skypjack/entt) - Gaming meets modern C++, a fast and reliable entity-component system (ECS) and much more
 
 ### AI
 


### PR DESCRIPTION
`EnTT` started as a fast ECS in C++ a while ago and now is getting a general purpose framework for game development. It's used also by Mojang in Minecraft (bedrock), link on the README. This is why I think it's worth adding it to this list.  
It has a MIT license.