### PR TITLE
Typo graphics -> games in description (heaps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Code
 * [Grid](http://www.planimeter.org/grid-sdk/) - Lua Game Engine.
 * [Havok Vision](http://www.havok.com/vision-engine/) - a cross-platform game engine that provides a powerful and versatile multi-platform runtime technology.
 * :tada: [HaxeFlixel](http://haxeflixel.com/) - Create cross-platform games easier and free.
-* :tada: [Heaps](https://heaps.io/) - Cross platform graphics for high performance graphics.
+* :tada: [Heaps](https://heaps.io/) - Cross platform graphics for high performance games.
 * [Hive3D](http://www.eyelead.com/hive/) - Real Time Collaboration 3D engine.
 * :tada: [Horde3D](http://www.horde3d.org/) - small open source 3D rendering engine.
 * :tada: [iio.js](https://github.com/iioinc/iio.js) - A javascript library that speeds the creation and deployment of HTML5 Canvas applications


### PR DESCRIPTION
**Why do you think the link is worth adding on this list?**
Accuracy. I made a typo in the last PR.

Cross platform graphics for high performance **graphics**.
_to_
Cross platform graphics for high performance **games**.
