### PR TITLE
Update Ebiten's URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Code
 * :tada: [Duality](http://duality.adamslair.net/) - C# / OpenGL 2D Game Engine that comes with visual editor.
 * :tada: [ENGi](https://github.com/ajhager/engi) - A multi-platform 2D game library for Go.
 * :tada: [engo](https://engoengine.github.io/) - Engo is an open-source 2D game engine written in Go.
-* :tada: [Ebiten](https://hajimehoshi.github.io/ebiten/) - A dead simple 2D game library in Go.
+* :tada: [Ebiten](https://ebiten.org/) - A dead simple 2D game library in Go.
 * :tada: [Ejecta](http://impactjs.com/ejecta) - A Fast, Open Source JavaScript, Canvas & Audio Implementation for iOS.
 * :tada: [EnchantJS](http://enchantjs.com/) - A simple JavaScript framework for creating games and apps.
 * :tada: [EnTT](https://github.com/skypjack/entt) - Gaming meets modern C++, a fast and reliable entity-component system (ECS) and much more


### PR DESCRIPTION
This PR updates Ebiten's URL to https://ebiten.org/
