### PR TITLE
Fix MagicaVoxel is not Open Source but free to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Graphics
 #### Voxel Editors
 
 * :tada: [goxel](https://github.com/guillaumechereau/goxel)
-* :tada: [MagicaVoxel](https://ephtracy.github.io/)
+* :free: [MagicaVoxel](https://ephtracy.github.io/)
 * :free: [Q-Block](http://kyucon.com/qblock/)
 * :free: [Sproxel](http://sproxel.blogspot.com.br/)
 * :tada: [VoxelShop](https://blackflux.com/index.php)


### PR DESCRIPTION
MagicaVoxel is not Open Source. See their license on the home page:
https://ephtracy.github.io/index.html?page=mv_main
License
    Free to use for any project
    Credits to the software are appreciated (e.g. "created by MagicaVoxel")
    Selling the software (original or modified) is disallowed

