### PR TITLE
Added Matcaps and ecs-lib libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Graphics
 * :free: [Iconmonstr](http://iconmonstr.com/) - Another free icons resource for your games.
 * :money_with_wings: [Kenney Assets](http://kenney.nl/assets) - Royalty free assets
 * :free: [Liberated Pixel Cup assets](http://lpc.opengameart.org) - Free graphic assets of the Liberated Pixel Cup (LPC) held by the OpenGameArt forums
+* :free: [Matcaps](https://github.com/nidorx/matcaps#matcaps) - A Huge library of matcap textures in PNG and ZMT, organized by color.
 * :free: [OpenClipart](https://openclipart.org/) -  Collection of free cliparts.
 * :free: [OpenGameArt](http://opengameart.org/) -  a media repository intended for use with free software game projects.
 * :moneybag: [Oryx Design Lab](http://oryxdesignlab.com/) - Cheap high quality royalty free sprites
@@ -225,6 +226,7 @@ Code
 * :tada: [ENGi](https://github.com/ajhager/engi) - A multi-platform 2D game library for Go.
 * :tada: [engo](https://engoengine.github.io/) - Engo is an open-source 2D game engine written in Go.
 * :tada: [Ebiten](https://ebiten.org/) - A dead simple 2D game library in Go.
+* :tada: [ecs-lib](https://github.com/nidorx/ecs-lib#readme) - **ecs-lib** is a tiny and easy to use ECS (Entity Component System) library for game programming. It's written in Typescript but you can use on node.js and web browser too.
 * :tada: [Ejecta](http://impactjs.com/ejecta) - A Fast, Open Source JavaScript, Canvas & Audio Implementation for iOS.
 * :tada: [EnchantJS](http://enchantjs.com/) - A simple JavaScript framework for creating games and apps.
 * :tada: [EnTT](https://github.com/skypjack/entt) - Gaming meets modern C++, a fast and reliable entity-component system (ECS) and much more


### PR DESCRIPTION
Matcaps - A wide variety of Matcaps textures
ecs-lib - An Entity Component System (ECS) library in typescript

Why do you think the link is worth adding on this list?
They are two important libraries for game development.

Does this project has any License?

ecs-lib - https://github.com/nidorx/ecs-lib#license
Matcaps https://github.com/nidorx/matcaps#license

