### PR TITLE
Add raylib as an open source game engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Code
 * :tada: [QICI](http://www.qiciengine.com/) -  Efficient web-based tool for creating HTML5 games.
 * :moneybag: [RPGMaker](http://www.rpgmakerweb.com/) - series of programs for the development of role-playing games.
 * :tada: [Rajawali](https://github.com/Rajawali/Rajawali) - Android OpenGL ES 2.0/3.0 Engine
+* :tada: [raylib](https://www.raylib.com/) - a simple and easy-to-use library to enjoy videogames programming, hardware accelerated with OpenGL (1.1, 2.1, 3.3 or ES 2.0)
 * :tada: [Ren'Py](http://www.renpy.org/) - An open-source visual novel engine using the Python language in simplified form. It supports Windows, Mac OS X, Linux, Android and iOS.
 * :tada: [Rpgboss](http://rpgboss.com) - A 2d rpg game engine and editor based on scala and libgdx. Ease of use, with no programming knowledge.
 * :tada: [SDL](http://libsdl.org/) - SDL is a cross-platform library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.


### PR DESCRIPTION
**Why do you think the link is worth adding on this list?**

raylib is an excellent library for videogames programming with a very straightforward approach and tons of language bindings. It's ideal for programming novices, but - since it's written in plain C - is also perfectly feasible for larger project sizes.

raylib allows for multiplatform (including Windows, Linux, MacOS, Android and HTML5) 2D and 3D game development and provides functions for Font rendering, Animated 3D models, Textures, Shaders, Audio and even VR stereo rendering.

Aside from C and C++, raylib can also be used with C#, Go, Python, Rust, Node.js and many more due to a plethora of language bindings (see: https://github.com/raysan5/raylib/blob/master/BINDINGS.md).

I have no personal affiliation with the project, I'm just a very satisfied user :)

**Does this project has any License?**

Excerpt from https://www.raylib.com/license.html:
> raylib is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software.

