### PR TITLE
fix MakeHuman URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Graphics
 #### Modeling
 
 * :tada: [Blender](http://www.blender.org/)
-* :free: [MakeHuman](http://www.makehuman.org/)
+* :free: [MakeHuman](http://www.makehumancommunity.org/)
 * :free: [sculptris](http://pixologic.com/sculptris/)
 * :moneybag: [Maya](http://www.autodesk.com/products/maya/overview)
 * :moneybag: [3ds Max](http://www.autodesk.com/products/3ds-max/overview)


### PR DESCRIPTION
MakeHuman official page has moved.
13 May 2018
Makehuman.org IS NO LONGER the official page of makehuman project.

The new official page is makehumancommunity.org
The new official page of MakeHuman project is www.makehumancommunity.org, a great site maintained by the MH community that includes many services and tools: MakeHuman development, forum, bugtracker, FAQ, documentation and more.

Why do you think the link is worth adding on this list?
Please describe the answer here

Does this project has any License?
Please describe the answer here

