### PR TITLE
Add ZBrush in part of Modeling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Graphics
 * :free: [Sketchfab](https://sketchfab.com/) -  Publish & embed interactive 3D models.
 * :free: [SpriteLib](http://www.widgetworx.com/spritelib/) - a collection of static and animated graphic objects (also commonly known as sprites).
 * :free: [StickyPNG](http://www.stickpng.com/) - Free transparent PNG images.
-* :free: [TextureHaven](https://texturehaven.com/) - Free textures with additional maps like displacement and bump maps. Also HDRIs. 
+* :free: [TextureHaven](https://texturehaven.com/) - Free textures with additional maps like displacement and bump maps. Also HDRIs.
 * :free: [TextureKing](http://www.textureking.com/) - Free material stock textures
 * :free: [Tree Generator](http://arnaud.ile.nc/cantree/generator.php) - An Online tree generator.
 * :money_with_wings: [Vecteezy](http://www.vecteezy.com/) -  Free Vector Art.
@@ -170,6 +170,7 @@ Graphics
 * :moneybag: [3ds Max](http://www.autodesk.com/products/3ds-max/overview)
 * :moneybag: [modo](https://www.foundry.com/products/modo)
 * :free: [Clara.io](https://clara.io/)
+* :moneybag: [ZBrush](http://pixologic.com/)
 
 #### Terrain Generators
 


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
Common 3D modeling software is almost focus on low-ploy modeling. But ZBrush is professional in high-poly modeling. And Normal Map is now frequently used in 3D game industry. However, Normal Map is generated by projecting the geometrical details from  high-poly model to low-poly model. So ZBrush is a important modeling tools.

Does this project has any License?
ZBrush is a commercial software need to pay for it.

