### PR TITLE
add another spritesheet tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Graphics
 * :free: [ShoeBox](http://renderhjs.net/shoebox/) - Adobe Air based app with game and ui related tools.
 * :tada: [Sprite Sheet Packer](https://github.com/nickgravelyn/SpriteSheetPacker/) - Combine multiple images into a single sprite sheet and generate a txt map of it.
 * :money_with_wings: [TexturePacker](https://www.codeandweb.com/texturepacker) - Great spritesheet creation editor.
+* :tada: [Tilesplit](https://github.com/AlexPoulsen/tilesplit) - CLI text-based tilesheet splitter and namer. Turn a spritesheet into many separate files with names you pick, or not if you don't care. Support templates and textures that are not all the same size.
 
 #### Bitmap Compression
 


### PR DESCRIPTION
I'm submitting my tool because I've found it very useful in game-related work I've done. Basically everything in it was created to make my life easier and I think anyone who needs separate files and finds it easier to draw in a larger tilesheet will get a lot out of using it. I've helped a few people use it so far. They were going to export each texture in it one by one and were really happy to know they could do it in a much faster/easier way. Hopefully some other people can get something out of it too.

I wasn't sure if it had one because I have a bad habit of not putting licenses on stuff and procrastinating doing something about that, but I checked and it is listed as MIT.

There's documentation for nearly all of it as well.

An example of its efficacy for a very repetitive tilesheet, I used 64 significant lines of input to export 1659 files. Most tilesheets won't be this dense though.
