### PR TITLE
Add 6502 Unit Test executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ _Set of game frameworks, engines and platforms_
 
 ### Engines and Frameworks
 
+- :tada: [6502 Unit Test executor](https://github.com/AsaiYusuke/6502_test_executor) - A cross-platform unit testing tool for MOS 6502 assembly. (i.e. NES)
 - :tada: [Allegro](http://liballeg.org/) - Allegro 4 & 5 are cross-platform, open source, game programming libraries, primarily for C and C++ developers.
 - :tada: [Amethyst](https://www.amethyst.rs/) - Data-driven game engine written in Rust for 2D & 3D using `gfx-rs`.
 - :tada: [amulet](http://www.amulet.xyz/) - A free Lua-based audio/visual toolkit suitable for small games and experimentation. It runs on Windows, Mac, Linux, HTML5 and iOS.


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
This tool provides a powerful UNIT testing capability that has not existed in NES console(MOS 6502) development environment until now.

Does this project has any License?
MIT

