### PR TITLE
Add Barotrauma to Complete Game Sources as open-source game

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ _Blogs, portals, magazines and more_
 
 ### Complete Game Sources
 
+- :tada: [Barotrauma](https://github.com/Regalis11/Barotrauma)
 - :tada: [Canabalt iOS](https://github.com/ericjohnson/canabalt-ios)
 - :tada: [Doom 3](https://github.com/id-Software/DOOM-3)
 - :tada: [Doom](https://github.com/id-Software/DOOM)


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
[Barotrauma](https://barotraumagame.com/wiki/Main_Page) is a popular open-source game created with the MonoGame engine. 

- 1.5 :star: [on GitHub](https://github.com/Regalis11/Barotrauma)
- ~1.5-3M owners
- ~3-5k concurrent players

[steamdb](https://steamdb.info/app/602960/charts/#all)

Does this project has any License?
Yes, [unfortunately it is quite restrictive](https://github.com/Regalis11/Barotrauma/blob/master/EULA.txt). I still think it might be worth adding as a MonoGame implementation reference.
