### PR TITLE
Add MapperMate as a Tile / Level Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 
 - :moneybag: [AutoTileGen](http://pixelatto.com) - AutoTileGen is an automatic tileset generator for 2D game terrains.
 - :tada: [LDtk](https://deepnight.net/tools/ldtk-2d-level-editor/) - LDtk is an open-source 2D level editor for indie devs, with a strong focus on user-friendliness.
-- :free: [MapperMate](https://mappermate.com/) - A cloud based tile map editor used to create 2D levels directly in the browser.
+- :money_with_wings: [MapperMate](https://mappermate.com/) - A cloud based tile map editor used to create 2D levels directly in the browser.
 - :tada: [Material Maker](https://github.com/RodZill4/material-maker) - procedural texture creator made in Godot
 - :tada: [OGMO Editor](https://ogmo-editor-3.github.io/)- generic level editor.
 - :tada: [Overlap2D](https://github.com/UnderwaterApps/overlap2d/) - a 2D level and UI editor with an engine agnostic philosophy.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 
 - :moneybag: [AutoTileGen](http://pixelatto.com) - AutoTileGen is an automatic tileset generator for 2D game terrains.
 - :tada: [LDtk](https://deepnight.net/tools/ldtk-2d-level-editor/) - LDtk is an open-source 2D level editor for indie devs, with a strong focus on user-friendliness.
+- :free: [MapperMate](https://mappermate.com/) - A cloud based tile map editor used to create 2D levels directly in the browser.
 - :tada: [Material Maker](https://github.com/RodZill4/material-maker) - procedural texture creator made in Godot
 - :tada: [OGMO Editor](https://ogmo-editor-3.github.io/)- generic level editor.
 - :tada: [Overlap2D](https://github.com/UnderwaterApps/overlap2d/) - a 2D level and UI editor with an engine agnostic philosophy.


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
MapperMate is the only cloud-based map editor in existence from what I'm aware of today. Users can easily create stunning game maps, then come back to them at any time, on any machine, anywhere.

All features are completely free for a user's first map, so they can create a full game or something exquisite without ever worrying about payments.

Does this project has any License?
No license

