### PR TITLE
Update correct Pygame library

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ _Set of game frameworks, engines and platforms_
 - :money_with_wings: [PlayCanvas](https://playcanvas.com/) - A WebGL Game Engine.
 - :tada: [Processing](https://www.processing.org/) - Processing is a programming language, development environment for artists, designers, researchers.
 - :tada: [PuzzleScript](http://www.puzzlescript.net/) - open-source HTML5 puzzle game engine.
-- :tada: [PyGame](http://pygame.org/hifi.html) - a 2D game engine in Python.
+- :tada: [PyGame-CE](https://pyga.me/docs/index.html) - Pygame - Community Edition is a FOSS Python library for multimedia applications (like games). Built on top of the excellent SDL library
 - :tada: [Pyxel](https://github.com/kitao/pyxel) - a retro game engine for Python.
 - :moneybag: [RPGMaker](http://www.rpgmakerweb.com/) - series of programs for the development of role-playing games.
 - :tada: [Rajawali](https://github.com/Rajawali/Rajawali) - Android OpenGL ES 2.0/3.0 Engine


### PR DESCRIPTION
Pygame-ce is a fork of pygame. It was created after some conflict that occurred that prevented developers from contributing to the main library. Pygame-ce is the one most commonly recommended.

Why do you think the link is worth adding on this list?
Please describe the answer here
- This updates the newer documentation of Pygame-CE URL and changes the name of `Pygame` to `PyGame-CE`. 
- I couldn't find a new updated version for the `[Making Games with Python & Pygame](http://inventwithpython.com/pygame/)` but I did find however an up-to-date blog post that you could create web games with the library: https://medium.com/@davesides3/python-games-in-the-browser-with-pygame-ce-pyscript-and-itch-io-5e730185dbff 

Does this project has any License?
Please describe the answer here
https://www.gnu.org/licenses/lgpl-3.0.html 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the "Engines and Frameworks" section to reference "PyGame-CE" with an improved description and updated link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->