### PR TITLE
Add Box2D.NET to Engines and Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ _Set of game frameworks, engines and platforms_
 - :tada: [Blitz3D](https://github.com/blitz-research/blitz3d) 3D basic-like programming language for fast 3D desktop games.
 - :tada: [boardgame.io](https://github.com/boardgameio/boardgame.io) - State management and multiplayer networking for turn-based games.
 - :tada: [Box2D](http://box2d.org/) - A 2D Physics Engine for Games.
+- :tada: [Box2D.NET](https://github.com/ikpil/Box2D.NET) - A port of Box2D, is a 2D physics engine for games, .NET C#, Unity3D, servers.
 - :tada: [Bullet](http://bulletphysics.org/wordpress/) - Real-time physics simulation.
 - :tada: [Chipmunk C#](https://github.com/netonjm/ChipmunkSharp) - C# implementation of the Chipmunk2D lib.
 - :tada: [Chipmunk2D](https://chipmunk-physics.net/) - A fast and lightweight 2D game physics library.


### PR DESCRIPTION
- A port of Box2D, is a 2D physics engine for games, .NET C#, Unity3D, servers.
- https://github.com/ikpil/Box2D.NET

English
---
Why do you think the link is worth adding on this list?
- When developing in a .NET environment, having a fully C#-based implementation of Box2D makes development much more convenient.

- Considering game development across all .NET environments, it allows for safe usage and easy debugging of 2D physics, helping to accelerate the development process.

Does this project has any License?
- MIT

Korean
---
추가할 가치가 있다고 생각하는 이유
- .NET 환경에서 개발할 때, 완전한 C# 으로 작성된 Box2D 가 있다면, 개발이 편해집니다.
- 모든 .NET 환경에서 게임을 개발한다고 생각했을 때, 안전하게 2D 물리를 사용하고 디버깅 할 수 있으므로, 더 빠른 개발을 할 수 있도록 도와줍니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added "Box2D.NET" to the "Engines and Frameworks" section in the README, highlighting its use as a .NET C# and Unity3D port of the Box2D 2D physics engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->