### PR TITLE
Add AI Game Developer link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ _Set of game frameworks, engines and platforms_
 - :tada: [WhiteStorm.js](https://github.com/WhitestormJS/whitestorm.js) - 3d javacript framework for building apps and games
 
 ### AI
+- :tada: [AI Game Developer](https://github.com/IvanMurzak/Unity-MCP) - `Unity Editor` and `Unity Runtime` AI integration. Unit Test, Coding, C# Roslyn, Reflection, Assets. Helps to create games with AI. And helps to run AI logic in during gameplay. 
 - :money_with_wings: [Coplay](https://coplay.dev?ref=github&utm_source=magictools) - AI Copilot for Unity
 - :tada: [Fluent Behaviour Tree](https://github.com/codecapers/Fluent-Behaviour-Tree) - C# behaviour tree library with a fluent API released under MIT.
 - :tada: [SimpleAI](https://github.com/mgerhardy/simpleai/) - C++11 behaviour tree based library with a QT5 based remote debugger (and with optional LUA bindings) released under MIT.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ _Set of game frameworks, engines and platforms_
 - :tada: [WhiteStorm.js](https://github.com/WhitestormJS/whitestorm.js) - 3d javacript framework for building apps and games
 
 ### AI
-- :tada: [AI Game Developer](https://github.com/IvanMurzak/Unity-MCP) - `Unity Editor` and `Unity Runtime` AI integration. Unit Test, Coding, C# Roslyn, Reflection, Assets. Helps to create games with AI. And helps to run AI logic in during gameplay. 
+- :tada: [AI Game Developer](https://github.com/IvanMurzak/Unity-MCP) - `Unity Editor` and `Unity Runtime` AI integration. Unit Test, Coding, C# Roslyn, Reflection, Assets. Helps to create games with AI. And helps to run AI logic during gameplay.
 - :money_with_wings: [Coplay](https://coplay.dev?ref=github&utm_source=magictools) - AI Copilot for Unity
 - :tada: [Fluent Behaviour Tree](https://github.com/codecapers/Fluent-Behaviour-Tree) - C# behaviour tree library with a fluent API released under MIT.
 - :tada: [SimpleAI](https://github.com/mgerhardy/simpleai/) - C++11 behaviour tree based library with a QT5 based remote debugger (and with optional LUA bindings) released under MIT.


### PR DESCRIPTION
Added a new entry for 'AI Game Developer' under the AI section.

## Why do you think the link is worth adding on this list?
**[AI Game Developer](https://github.com/IvanMurzak/Unity-MCP)** as AI integration with Unity Engine (game engine). It helps to develop games in many ways. Run tests, read and modify Unity Assets, operate in Unity environment in many ways.

![level-building (2)_optimized](https://github.com/user-attachments/assets/ec66324a-bb49-451e-b822-e153d6ba6f2a)

You may view gif demos [here](https://github.com/IvanMurzak/Unity-MCP/tree/main/docs/img), and videos [here](https://www.youtube.com/watch?v=kQUOCQ-c0-M&list=PLyueiUu0xU70uzNoOaanGQD2hiyJmqHtK).


## Does this project has any License?
[Apache 2.0 License](https://github.com/IvanMurzak/Unity-MCP?tab=Apache-2.0-1-ov-file#readme)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “AI Game Developer” entry to the README’s AI section.
  * Provides a high-level description of Unity Editor and Runtime AI integration for user understanding.
  * Improves discoverability and guidance on where to find and learn about this AI feature in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->