### PR TITLE
Add NormalPainter to the list of art tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 - :tada: [LibreSprite](https://libresprite.github.io/) - LibreSprite is an open source fork of Aseprite.
 - :moneybag: [Lightcube](https://www.lightcube.art/) - Pixel Art Editor for Windows, supposed PSD files in addition to JPEG, PNG, BMP, GIF.
 - :free: [Multipaint](http://multipaint.kameli.net) - A cross-platform (Win, Linux, Mac) image editor/painter which covers the color limitations of 8-bit machines (like C64, ZX Spectrum etc.)
+- :free: [NormalPainter](https://winteralexander.itch.io/normalpainter) - An editor for hand painting stylized normal maps with graphical tablet and joystick support
 - :money_with_wings: [Paint.NET](http://www.getpaint.net/) - Paint.NET is free image and photo editing software for PCs that run Windows.
 - :moneybag: [Pickle](http://www.pickleeditor.com/) - Another Pixel art Editor.
 - :tada: [PiskelApp](http://www.piskelapp.com/) - Free Online Pixel Art and Animated Sprite Tool.


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
- The tool added fills a unique and specific need (stylized hand painted normal maps) using a unique and interesting technique not explored in other image editing tools. (It allows using the tilt of a graphical pen or joystick to draw the direction of the surface being painted).

Does this project has any License?
- MIT license 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NormalPainter to the Graphics/Vector/Image Editor section—a free tool for hand-painting stylized normal maps with tablet and joystick support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->