### PR TITLE
Add steamworks-ffi-node to the engines and frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ _Set of game frameworks, engines and platforms_
 - :free: [SpriteKit](https://developer.apple.com/documentation/spritekit) - Apple proprietary 2D game engine (available on macOS, iOS, iPadOS, tvOS and watchOS).
 - :tada: [Stage.js](http://piqnt.com/stage.js/) - Lightweight and fast 2D HTML5 rendering and layout engine for cross-platform game development.
 - :tada: [Starling](http://gamua.com/starling/) - The GPU powered 2D Flash API
-- :free: [steamworks-ffi-node](https://github.com/ArtyProf/steamworks-ffi-node) - a Node.js wrapper for Steamworks SDK.
+- :tada: [steamworks-ffi-node](https://github.com/ArtyProf/steamworks-ffi-node) - a Node.js wrapper for Steamworks SDK.
 - :money_with_wings: [Stencyl](http://www.stencyl.com/) - a game creation platform that allows users to create 2D video games for computers, mobile devices, and the web.
 - :tada: [Stride](https://stride3d.net/) - Open Source C# Game Engine.
 - :tada: [Supernova Engine](https://supernovaengine.org/) - Cross-platform game engine for 2D and 3D projects with entity component system (ECS) and data-oriented design in C++ and Lua.


### PR DESCRIPTION
Hi @ellisonleao 

I am suggesting to add my library called [steamworks-ffi-node](https://github.com/ArtyProf/steamworks-ffi-node) to the engines and frameworks section as it a Node.js wrapper for working with Steamworks SDK. That allow devs who building games or apps on js frameworks to different steam integrations like achievements, stats, workshop, cloud etc. Also provide full documentation with lot's of examples unlike existing libraries.

Project is under the MIT license and open source.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "steamworks-ffi-node" to the Engines and Frameworks list.
  * Inserted the new entry adjacent to the existing Starling entry, positioned before Stencyl.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->