### PR TITLE
Add Legend of Elya to Complete Game Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ _Blogs, portals, magazines and more_
 - :tada: [Doom 3](https://github.com/id-Software/DOOM-3)
 - :tada: [Doom](https://github.com/id-Software/DOOM)
 - :tada: [Duke Nukem 3D: Atomic Edition](http://legacy.3drealms.com/duke3d/)
+- :tada: [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - N64 dungeon crawler with AI NPCs powered by an 819K-parameter LLM running on the MIPS R4300i
 - :tada: [NetHack](https://github.com/NetHack/NetHack)
 - :tada: [OpenRA](https://github.com/OpenRA/OpenRA)
 - :tada: [OpenTTD](https://github.com/OpenTTD/OpenTTD)


### PR DESCRIPTION
## Summary

Adds [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) to the Complete Game Sources section.

Legend of Elya is a Nintendo 64 dungeon crawler with AI NPCs powered by an 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i at 60 tokens/second. It's the world's first LLM running on N64 hardware.

- Full C source code available
- Built with libdragon SDK
- Produces a playable .z64 ROM
- Open source (MIT license)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Legend of Elya to the complete game sources list. This N64 dungeon crawler entry features AI-powered NPC interactions, expanding the available game examples in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->