### PR TITLE
Add new voxel editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 - :tada: [goxel](https://github.com/guillaumechereau/goxel)
 - :free: [MagicaVoxel](https://ephtracy.github.io/)
 - :free: [Sproxel](http://sproxel.blogspot.com.br/)
+- :free: [Voxelle Desktop](https://github.com/Velfi/Voxelle-Desktop)
 
 ## Code
 


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
Voxelle Desktop is a new, easy-to-use voxel editor that can export GLTF models.

Does this project has any License?
It's free, open source software



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new free voxel editor resource to the Graphics tools reference section in the repository documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->