### PR TITLE
Add Questlog to Project Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ _Blogs, portals, magazines and more_
 - :money_with_wings: [Codecks](https://www.codecks.io) - Project Management Tool inspired by Collectible Card Games
 - :money_with_wings: [IMS Creators](https://ims.cr5.space/) - Game Design driven Project Management Tool
 - :money_with_wings: [HacknPlan](http://hacknplan.com/) - Project management for game developers
+- :money_with_wings: [Questlog](https://www.questlog.build) - Project management built for game developers. Kanban boards, bug tracking with severity, milestones, and a built-in GDD editor. Free for solo devs.
 - :money_with_wings: [Taiga](https://taiga.io/) - Project management platform for agile developers & designers
 - :money_with_wings: [Trello](https://trello.com/) - Organize and prioritize projects
 

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ _Blogs, portals, magazines and more_
 - :money_with_wings: [Codecks](https://www.codecks.io) - Project Management Tool inspired by Collectible Card Games
 - :money_with_wings: [IMS Creators](https://ims.cr5.space/) - Game Design driven Project Management Tool
 - :money_with_wings: [HacknPlan](http://hacknplan.com/) - Project management for game developers
-- :money_with_wings: [Questlog](https://www.questlog.build) - Project management built for game developers. Kanban boards, bug tracking with severity, milestones, and a built-in GDD editor. Free for solo devs.
+- :money_with_wings: [Questlog](https://www.questlog.build) - Project management for game developers with built-in GDD editor
 - :money_with_wings: [Taiga](https://taiga.io/) - Project management platform for agile developers & designers
 - :money_with_wings: [Trello](https://trello.com/) - Organize and prioritize projects
 


### PR DESCRIPTION
Why do you think the link is worth adding on this list?

- Questlog is a project management tool built specifically for game developers — the same niche as HacknPlan, Codecks, and IMS Creators which are already on this list. It has Kanban boards for tasks and bugs with severity levels, milestones with burndown, a built-in GDD editor, and discipline/platform tags (code/art/audio/design). Free forever for solo developers, with a paid team tier. Fills the same slot as the other entries in the Project Management section.

Does this project has any License?
- Questlog is a hosted SaaS (not open source). It's free to use for solo developers and has a paid Party plan (€9.99/mo) for teams — which matches the :money_with_wings: (Partially Free) license tag used by the other entries in the Project Management section (HacknPlan, Codecks, Taiga, Trello, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Questlog (https://www.questlog.build) to Project Management resources — highlighted as a tool for game developers with a built-in Game Design Document (GDD) editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->