### PR TITLE
Add Meccha Chameleon Art fan atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,3 +564,8 @@ _Online courses, tutorials, screencasts_
 - :free: [3D Game Shaders For Beginners](https://github.com/lettier/3d-game-shaders-for-beginners)
 - :free: [Interactive 3D Graphics](https://www.udacity.com/course/interactive-3d-graphics--cs291)
 - :moneybag: [Interactive Computer Graphics](https://www.coursera.org/learn/interactive-computer-graphics)
+
+## Community Resource Additions
+
+<!-- Added 2026-06-24 by zlc000190 -->
+- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon, a paint-based hide-and-seek Steam game. 50+ hiding spot atlas with color analysis, bilingual (EN/中文). GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot


### PR DESCRIPTION
## Community Resource

- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon, a paint-based hide-and-seek Steam game. 50+ hiding spot atlas with color analysis, bilingual (EN/中文).
- GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot

Fan-made, unofficial. Meccha Chameleon is © LEMORION.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section for community-contributed resources with curated links and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->