### PR TITLE
Add Mixos (free browser-based PBR texture painter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 
 - :moneybag: [FilterForge](https://www.filterforge.com/) - A plugin for Adobe Photoshop that allows you to build your own filters.
 - :free: [Live Normal](https://tenebrislab.github.io/livenormal/) - An Android and iOS app for generating seamless materials on the go. You take a photo, and Live Normal creates a tile-able texture and generates texture maps ready for a PBR engine of your choice.
+- :free: [Mixos](https://www.mixos.io) - Browser-based 3D texture painter — paint, layer & mask PBR materials on any model, bake maps, generate with AI, export render-ready maps. No install.
 - :moneybag: [PixPlant](http://www.pixplant.com/) - PixPlant is a smart 3D texturing tool that creates high quality normal, displacement, specular maps and seamless textures from photos.
 
 #### Character Generators


### PR DESCRIPTION
Adds **Mixos** to the *Texture Tools* section — a free, browser-based 3D PBR texture painter: paint, layer and mask materials directly on the mesh, bake mesh maps (AO, curvature, normal), generate materials/textures/masks with AI, and export standard PBR map sets. Runs in the browser, no install or account needed: https://www.mixos.io

Placed alphabetically within the section. Thanks for maintaining magictools!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **Mixos** entry to the **Texture Tools** section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->