### PR TITLE
Add AnimKit to Graphics > Animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 
 #### Animation
 
+- :moneybag: [AnimKit](https://www.nasrtech.dev/animkit) - Maya animation toolkit with live tweening, smart keys, motion trails, a pose library and Mixamo retargeting. An affordable animBot alternative.
 - :money_with_wings: [Cascadeur](https://cascadeur.com/) - Powerful physics-based 3D character animation
 - :tada: [LWF](http://gree.github.io/lwf/) - Lightweight SWF. LWF is an animation engine which can play animation data converted from FLASH contents in HTML5, Unity, Cocos2d-x, iOS UIKit, and more.
 - :moneybag: [Fusion Character Animator](http://loopengo.free.fr/) - small tool for Clickteam Fusion 2.5 to facilitate the animation of 2D character sprites for developers.


### PR DESCRIPTION
Adds **[AnimKit](https://www.nasrtech.dev/animkit)** to the *Graphics > Animation* section.

AnimKit is a Maya animation toolkit (paid, tagged `:moneybag:`) — live tweening, smart keys, speed-colored motion trails, a pose library with mirror/flip, and Mixamo auto-retargeting. It sits alongside Cascadeur and Mixamo as a 3D character-animation tool.

Placed first in the list (alphabetical). Thanks for maintaining magictools!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new AnimKit resource link to the Animation section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->