### PR TITLE
Add Image Dithering Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 - :moneybag: [Affinity Photo](https://affinity.serif.com/de/photo) - Photo and raster graphics editor which works together with Adobe file formats and Affinity Designer
 - :money_with_wings: [Aseprite](http://www.aseprite.org/) - animated sprite editor & pixel art tool.
 - :tada: [Gimp](http://www.gimp.org/) - GNU Image Manipulation Program. It is a freely distributed piece of software for such tasks as photo retouching, image composition and image authoring.
+- :free: [Image Dithering Tool](https://alltoolsverse.com/tools/apply-dithering-to-image/) - Apply Floyd-Steinberg, Ordered Bayer, or Atkinson dithering to images in the browser and export the result as PNG.
 - :tada: [Inkscape](https://inkscape.org/en/) - An open-source vector graphics editor similar to Adobe Illustrator, Corel Draw, Freehand, or Xara X.
 - :tada: [Krita](https://krita.org/) - Krita is a professional FREE and open source painting program. It is made by artists that want to see affordable art tools for everyone.
 - :tada: [LibreSprite](https://libresprite.github.io/) - LibreSprite is an open source fork of Aseprite.


### PR DESCRIPTION
Why do you think the link is worth adding on this list?

Image Dithering Tool is a focused, free browser utility that applies Floyd-Steinberg, Ordered Bayer, and Atkinson dithering to images and exports PNG results. Dithering is useful for retro visuals and pixel-art workflows, so it fits the Graphics > Vector/Image Editor section. I tested all three algorithms with a real WebP image before opening this PR.

Does this project has any License?

The hosted tool is free to use, but it is not presented as an open-source project. I used the `:free:` label rather than `:tada:`.

Disclosure: I am the maker of All Tools Verse and am submitting one individual utility, not the directory. OpenAI Codex assisted with research, live testing, and preparing this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Image Dithering Tool to the Vector/Image Editor resources.
  * Linked to a browser-based tool supporting Floyd-Steinberg, Ordered Bayer, and Atkinson dithering with PNG export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->