### PR TITLE
Add Palette Extractor to Vector/Image Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 - :free: [Multipaint](http://multipaint.kameli.net) - A cross-platform (Win, Linux, Mac) image editor/painter which covers the color limitations of 8-bit machines (like C64, ZX Spectrum etc.)
 - :free: [NormalPainter](https://winteralexander.itch.io/normalpainter) - An editor for hand painting stylized normal maps with graphical tablet and joystick support
 - :money_with_wings: [Paint.NET](http://www.getpaint.net/) - Paint.NET is free image and photo editing software for PCs that run Windows.
+- :tada: [Palette Extractor](https://pixelpixi.github.io/spritewright/palette-extractor/) - Extract the exact colour palette from any sprite or image in the browser and export it as GIMP/Aseprite .gpl, Lospec .hex, CSS, JSON or a PNG strip. Runs locally, nothing is uploaded. [Source](https://github.com/pixelpixi/spritewright)
 - :moneybag: [Pickle](http://www.pickleeditor.com/) - Another Pixel art Editor.
 - :tada: [PiskelApp](http://www.piskelapp.com/) - Free Online Pixel Art and Animated Sprite Tool.
 - :moneybag: [Pixelmator](http://www.pixelmator.com) - Full-featured image editing app for the Mac


### PR DESCRIPTION
Adds a free, open-source browser tool for pulling the exact colour palette out of a sprite, tileset or image.

**https://pixelpixi.github.io/spritewright/palette-extractor/** — source: https://github.com/pixelpixi/spritewright (MIT)

Why it might be a fit: the list currently has no palette tool of any kind, and this covers the export formats gamedevs actually need — GIMP/Aseprite `.gpl`, Lospec `.hex`, CSS custom properties, JSON, and a PNG swatch strip. It runs entirely client-side, so no upload and no account.

Placed alphabetically in Graphics > Vector/Image Editor, tagged :tada: with a [Source] link to match the existing open-source entries. One entry, one line.

Disclosure: I wrote it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Palette Extractor to the Vector/Image Editor resources.
  * Documented browser-based color palette extraction, export formats, local processing, and source repository details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->