### PR TITLE
Add PixelChart sprite sheet and normal map tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 - :tada: [EzSpriteSheet](https://github.com/z64me/EzSpriteSheet) - Creates sprite sheets from animated GIFs and more
 - :tada: [Libgdx Texture Packer](https://github.com/libgdx/libgdx/wiki/Texture-packer) - Texture Packer built into Libgdx
 - :free: [Littera](http://kvazars.com/littera) - Bitmap font generator
+- :free: [PixelChart Sprite Sheet Tools](https://pixelchart.app/tools/sprite-sheet-maker/) - Pack frames into a sheet with a JSON atlas, slice sheets back into PNGs, and convert between sheets and animated GIFs. Runs in the browser, no upload.
 - :tada: [SnowB Bitmap Font](https://snowb.org/) - Bitmap font generator
 - :free: [ShoeBox](http://renderhjs.net/shoebox/) - Adobe Air based app with game and ui related tools.
 - :money_with_wings: [TexturePacker](https://www.codeandweb.com/texturepacker) - Great spritesheet creation editor.
@@ -107,6 +108,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 
 - :moneybag: [FilterForge](https://www.filterforge.com/) - A plugin for Adobe Photoshop that allows you to build your own filters.
 - :free: [Live Normal](https://tenebrislab.github.io/livenormal/) - An Android and iOS app for generating seamless materials on the go. You take a photo, and Live Normal creates a tile-able texture and generates texture maps ready for a PBR engine of your choice.
+- :free: [PixelChart Normal Map Generator](https://pixelchart.app/tools/normal-map-generator/) - Turns an image into normal, height and ambient occlusion maps with a live WebGL lit preview. Exports PNG or ZIP, runs entirely in the browser.
 - :moneybag: [PixPlant](http://www.pixplant.com/) - PixPlant is a smart 3D texturing tool that creates high quality normal, displacement, specular maps and seamless textures from photos.
 
 #### Character Generators


### PR DESCRIPTION
**Why do you think the link is worth adding on this list?**

Disclosure up front: I built these, so weigh that as you see fit.

Two gaps I kept running into myself:

1. **Spritesheet Tools** — the packers here are desktop apps or CLIs. This one runs in the browser: it packs frames into a sheet with a TexturePacker-style JSON atlas, slices an existing sheet back into individual PNGs or a ZIP, and converts both ways between a sheet and an animated GIF. Useful when you just need to unpack someone else's sheet without installing anything.

2. **Texture Tools** — the section has one free option right now and it's a mobile app. This takes a single image and produces normal, height and ambient occlusion maps, with a WebGL lit preview so you can check the result before exporting to PNG or ZIP.

Both are free, need no account, and do all the work client-side — images never leave the browser, so they also keep working offline once loaded. No AI involved: the normal map comes from a Rec. 709 luminance pass, a separable blur and a Sobel filter, so the same input always gives the same output.

Happy to drop either entry if you think one of them doesn't fit the section.

**Does this project has any License?**

The tools are free to use but not open source, so there's no license to point at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PixelChart’s Sprite Sheet Tools resource under Spritesheet Tools.
  * Added PixelChart’s Normal Map Generator resource under Texture Tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->