### PR TITLE
Add Ludo.ai to Code > AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ _Set of game frameworks, engines and platforms_
 - :tada: [AI Game Developer](https://github.com/IvanMurzak/Unity-MCP) - `Unity Editor` and `Unity Runtime` AI integration. Unit Test, Coding, C# Roslyn, Reflection, Assets. Helps to create games with AI. And helps to run AI logic during gameplay.
 - :money_with_wings: [Coplay](https://coplay.dev?ref=github&utm_source=magictools) - AI Copilot for Unity
 - :tada: [Fluent Behaviour Tree](https://github.com/codecapers/Fluent-Behaviour-Tree) - C# behaviour tree library with a fluent API released under MIT.
+- :money_with_wings: [Ludo.ai](https://ludo.ai) - AI sprite generator for game-ready 2D assets, extending to icons, UI, textures, music, 3D and video, in 30+ art styles or matched to your own style references. Ships an MCP server, REST API and Unity plugin.
 - :money_with_wings: [Rosebud AI](https://rosebud.ai) - Vibe coding platform for creating 3D games and interactive web apps with AI.
 - :money_with_wings: [Sprite Fusion AI Pixel Art Generator](https://www.spritefusion.com/pixel-art-generator) - AI-powered browser studio for generating, editing, animating, and exporting game-ready pixel art sprites, icons, props, and spritesheets.
 - :tada: [SimpleAI](https://github.com/mgerhardy/simpleai/) - C++11 behaviour tree based library with a QT5 based remote debugger (and with optional LUA bindings) released under MIT.


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
-------------------------------------------------------

The AI section collects tools that generate game content, and Ludo.ai sits alongside Sprite Fusion and Rosebud AI there: it generates sprites and other game-ready 2D assets, and extends to icons, UI, textures, music, 3D models and video from the same tool.

Two things that make it worth a line rather than being one more generator:

- **Style consistency across a project.** 30+ preset art styles, or you supply your own style references and it matches them across every asset, so a whole game keeps one visual language instead of drifting per prompt.
- **It lands in your pipeline, not a downloads folder.** An MCP server (usable from Claude, Cursor or any MCP client), a REST API, and a Unity plugin for dragging assets straight into a scene.

Indie teams have shipped with it, if that's useful for judging it beyond the marketing: [Echoes of Creation](https://ludo.ai/blog/indie-spotlight-echoes-of-creation) (solo dev, 230+ icons and a 24-track soundtrack) and [Abduct 'Em](https://ludo.ai/blog/indie-spotlight-abduct-em).

Does this project has any License?
----------------------------------

Proprietary, commercial SaaS. Free to start with 30 generation credits and no credit card; paid plans from $15/month. I tagged it `:money_with_wings:` (Partially Free) to match how Coplay and Rosebud AI are tagged in the same section, since there is a real free entry point but no permanently free tier.

Entry is alphabetical between Fluent Behaviour Tree and Rosebud AI, and the link is live.

---

Disclosure: I work on Ludo.ai, so this is a self-submission. Happy to shorten the description, retag it, or drop the PR entirely if it isn't a fit for the list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ludo.ai to the README’s list of AI game-development resources as a paid tool for generating sprites and game assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->