### PR TITLE
Add NixieFX to Graphics > Animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ _Great graphics placeholders and tools to turn that squared game into a picasso 
 - :free: [GameAsset.net](https://gameasset.net/) - 10,000+ free CC0 character animations, previewable in 3D with GLB download.
 - 🆓 [GraphicsDale](https://graphicsgale.com/us/) - Powerful tool for spriting and pixel art.
 - :moneybag: [Mixamo](https://www.mixamo.com/#/) - tool for auto auto rigging and animation of 3D humanoid models,
+- :tada: [NixieFX](https://nixiefx.com/) - Free browser-based particle and VFX editor for Three.js and PixiJS web games, with an open-source runtime.
 - :tada: [Pixel Composer](https://github.com/Ttanasart-pt/Pixel-Composer) - Powerful node-based VFX editor for pixel art
 - :moneybag: [Spine](http://esotericsoftware.com/) - Spine is dedicated to 2D animation, providing an efficient workflow both for creating amazing animation and for integrating it into your games.
 - :moneybag: [Spriter Pro](https://brashmonkey.com/download-spriter-pro/) - Modern tool for sprite animation.


### PR DESCRIPTION
Disclosure: I created and maintain NixieFX.

Why do you think the link is worth adding on this list?

NixieFX is a free browser-based particle and VFX authoring tool for web games. It lets developers create effects visually and run exported effects in Three.js or PixiJS through a shared deterministic runtime. It fits Graphics > Animation alongside the existing VFX-editor entry, while specifically supporting 2D and 3D web-game particle workflows.

Does this project has any License?

Yes. The NixieFX runtime and CLI are open source under the MIT License:
https://github.com/azakhary/nixie-fx/blob/main/LICENSE

The browser editor is free to use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NixieFX to the animation resources list as a free browser-based particle and visual effects editor for Three.js and PixiJS games.
  * Noted that NixieFX includes an open-source runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->