### PR TITLE
Add GameFrameX to Engines and Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ _Set of game frameworks, engines and platforms_
 - :free: :tada: [Folded Paper Engine](https://github.com/papercraftgames/folded-paper-engine) – Blender to Godot game mechanics engine/plug-ins. Just a few clicks. Super easy. Featuring: 2.5D/first-person/third-person controls, trigger commands/events, inventory, holdable items and all kinds of stuff.
 - :tada: [Forge](https://forgeleaf.com/forge) - Powerful and lightweight game framework for Go.
 - :tada: [Foster](https://github.com/FosterFramework/Foster) - A small cross-platform 2D game framework in C#.
+- :tada: [GameFrameX](https://github.com/GameFrameX/GameFrameX) - A cross-engine game framework: Unity and Godot clients on a single actor-model .NET server, sharing one Protobuf contract and LuBan config pipeline. AI-agent friendly: instruction docs in-repo, codegen'd protocol/config layers.
 - :money_with_wings: [GameMaker](https://gamemaker.io/) - GameMaker accommodates the creation of cross-platform video games using drag and drop or a scripting language known as Game Maker Language, which can be used to develop more advanced games that could not be created just by using the drag and drop features.
 - :tada: [gameplay](http://gameplay3d.io/) - A free, open-source, cross-platform, 2D + 3D game framework written in C++. It is aimed towards indie game developers who are creating desktop and mobile games.
 - :money_with_wings: [GameSalad](https://gamesalad.com/) - Game Creation Engine for Mac and Windows.


### PR DESCRIPTION
Adds GameFrameX under Code → Engines and Frameworks.

**What it is:** a cross-engine game framework — Unity (HybridCLR) and Godot 4 C# clients on a single actor-model .NET 10 server. One Protobuf contract and one LuBan config pipeline serve every platform; hot-update works on both client and server. Free software (AGPL-3.0).

**Why it fits:** this section is full of engines and single-purpose frameworks; GameFrameX is the rarer full-stack kind — client(s) *and* server designed together. The engine becomes a swappable medium; the game — protocols, config, actor logic — is the message that stays the same across Unity, Godot and the .NET backend.

**Differentiator:** every neighbour entry is a single engine or single library. GameFrameX is the cross-engine both-sides stack, and the one built for AI-assisted development: agent instruction docs (AGENTS.md/CLAUDE.md) checked into the repo, protocol & config generated by deterministic scripts (AI writes gameplay, never hand-rolled contracts), state/logic split confining AI edits to hot-update boundaries, daily CI verifying everything still compiles.

Actively maintained: daily CI across the aggregate repo, 5-language README, docs site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GameFrameX to the list of engines and frameworks.
  * Documented its support for Unity and Godot clients, .NET server architecture, Protobuf contracts, and LuBan configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->